### PR TITLE
Plotting extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,10 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
+WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"
+
+[extensions]
+NeumannKelvinWGLMakieExt = "WGLMakie"
 
 [compat]
 DataInterpolations = "8.0.1"
@@ -29,6 +33,7 @@ SpecialFunctions = "2"
 StaticArrays = "1"
 ThreadsX = "0.1.12"
 TypedTables = "1"
+WGLMakie = "0.11.7"
 julia = "1.9"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,14 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
-WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"
+
+[weakdeps]
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [extensions]
-NeumannKelvinWGLMakieExt = "WGLMakie"
+NeumannKelvinMakieExt = "Makie"
+NeumannKelvinPlotsExt = "Plots"
 
 [compat]
 DataInterpolations = "8.0.1"
@@ -33,7 +37,6 @@ SpecialFunctions = "2"
 StaticArrays = "1"
 ThreadsX = "0.1.12"
 TypedTables = "1"
-WGLMakie = "0.11.7"
 julia = "1.9"
 
 [extras]

--- a/ext/NeumannKelvinMakieExt.jl
+++ b/ext/NeumannKelvinMakieExt.jl
@@ -1,15 +1,7 @@
-module NeumannKelvinWGLMakieExt
-
-if isdefined(Base, :get_extension)
-    using WGLMakie; WGLMakie.activate!(inline=false)
-else
-    using ..WGLMakie; WGLMakie.activate!(inline=false)
-end
-
-using NeumannKelvin
-
+module NeumannKelvinMakieExt
+using NeumannKelvin,Makie
 # Generate full triangle mesh and color array
-function viz(panels, values; vectors=panels.n, colormap=:viridis)
+function NeumannKelvin.viz(panels::Table, values=panels.dA; vectors=0.3panels.n, colormap=:viridis, kwargs...)
     fig = Figure()
     ax = Axis3(fig[1, 1], aspect=:data)
 
@@ -28,9 +20,7 @@ function viz(panels, values; vectors=panels.n, colormap=:viridis)
 
     # Normals & color bar
     arrows!(ax, components(panels.x)..., components(vectors)...; color=colors)
-    Colorbar(fig[1, 2], limits=(vmin, vmax); colormap)
+    Colorbar(fig[1, 2], limits=(vmin, vmax); colormap, kwargs...)
     fig
 end
-export viz
-
 end

--- a/ext/NeumannKelvinPlotsExt.jl
+++ b/ext/NeumannKelvinPlotsExt.jl
@@ -1,0 +1,8 @@
+module NeumannKelvinPlotsExt
+using NeumannKelvin,Plots
+function NeumannKelvin.viz(panels::Table, values=panels.dA; vectors=0.3panels.n, kwargs...)
+    @warn "Using fallback Plots-based panel plotting. Load GLMakie or WGLMakie instead for more functionality." maxlog=1
+    scatter(components(panels.x),marker_z=values;label="",kwargs...)
+    quiver!(components(panels.x),quiver=components(vectors),color=:grey)
+end
+end

--- a/ext/NeumannKelvinWGLMakieExt.jl
+++ b/ext/NeumannKelvinWGLMakieExt.jl
@@ -1,0 +1,36 @@
+module NeumannKelvinWGLMakieExt
+
+if isdefined(Base, :get_extension)
+    using WGLMakie; WGLMakie.activate!(inline=false)
+else
+    using ..WGLMakie; WGLMakie.activate!(inline=false)
+end
+
+using NeumannKelvin
+
+# Generate full triangle mesh and color array
+function viz(panels, values; vectors=panels.n, colormap=:viridis)
+    fig = Figure()
+    ax = Axis3(fig[1, 1], aspect=:data)
+
+    # Normalize and map to color
+    vmin, vmax = extrema(values)
+    norm_vals = (values .- vmin) ./ (vmax - vmin + eps())
+    colors = cgrad(colormap)[norm_vals]
+
+    # Mesh geometry (triangle list) and colors
+    triangles = mapreduce(vcat, panels) do panel
+        p = panel.⛶
+        [p[1], p[2], p[3], p[4], p[3], p[2]]
+    end
+    tri_colors = mapreduce(c -> fill(c, 6), vcat, colors)
+    mesh!(ax, triangles; color=tri_colors)
+
+    # Normals & color bar
+    arrows!(ax, components(panels.x)..., components(vectors)...; color=colors)
+    Colorbar(fig[1, 2], limits=(vmin, vmax); colormap)
+    fig
+end
+export viz
+
+end

--- a/src/NeumannKelvin.jl
+++ b/src/NeumannKelvin.jl
@@ -23,4 +23,16 @@ export param_props,panelize
 include("panel_method.jl")
 export ∂ₙϕ,influence,ζ,steady_force,added_mass
 
+components(data) = ntuple(i -> getindex.(data, i), 3)
+export components
+
+# Backward compatibility for extensions
+if !isdefined(Base, :get_extension)
+    using Requires
+end
+function __init__()
+    @static if !isdefined(Base, :get_extension)
+        @require WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008" include("../ext/NeumannKelvinWGLMakieExt.jl")
+    end
+end
 end

--- a/src/NeumannKelvin.jl
+++ b/src/NeumannKelvin.jl
@@ -23,16 +23,9 @@ export param_props,panelize
 include("panel_method.jl")
 export ∂ₙϕ,influence,ζ,steady_force,added_mass
 
+# Plotting fallback
+viz(args...; kwargs...) = @warn "Pass a Table() of panels and load Plots or GLMakie (terminal/VSCode) or WGLMakie (browser/Pluto) for viz functionality."
 components(data) = ntuple(i -> getindex.(data, i), 3)
-export components
+export viz,components
 
-# Backward compatibility for extensions
-if !isdefined(Base, :get_extension)
-    using Requires
-end
-function __init__()
-    @static if !isdefined(Base, :get_extension)
-        @require WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008" include("../ext/NeumannKelvinWGLMakieExt.jl")
-    end
-end
 end


### PR DESCRIPTION
Adds `viz` function for plotting `panels::Table`. If Plots is loaded, it scatter plots the centers colored by the supplied value as well as grey lines for the normals. If Makie (tested on WGLMakie and GLMakie) is loaded, two triangles (extending to the panels corners) are plotted instead of just the panel center point. The vectors are also colored. 